### PR TITLE
Fixes config to match include

### DIFF
--- a/teraranger_hub/CMakeLists.txt
+++ b/teraranger_hub/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 generate_dynamic_reconfigure_options(
-  cfg/Teraranger_hub.cfg
+  cfg/TerarangerOne.cfg
 )
 
 # export the dependencis of this package for who ever depends on us

--- a/teraranger_hub/cfg/TerarangerOne.cfg
+++ b/teraranger_hub/cfg/TerarangerOne.cfg
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-PACKAGE = "teraranger_hub"
+PACKAGE = "terarangerone"
 
 from dynamic_reconfigure.parameter_generator_catkin import *
 
@@ -18,4 +18,4 @@ speed_enum = gen.enum([ gen.const("Fast",      int_t, 0, "Fast"),
 
 gen.add("Speed", int_t, 0, "Set the environment", 0, 0, 1, edit_method=speed_enum)
 
-exit(gen.generate(PACKAGE, "teraranger_hub", "Teraranger_hub"))
+exit(gen.generate(PACKAGE, "teraranger_hub", "TerarangerOne"))


### PR DESCRIPTION
Current build is failing for us in groovy due to a missing `teraranger_hub/TerarangerOneConfig.h`:
```
In file included from /home/asctec/catkin_ws/src/teraranger_hub/src/teraranger_hub.cpp:39:0:
/home/asctec/catkin_ws/src/teraranger_hub/include/teraranger_hub/teraranger_hub.h:48:48: fatal error: teraranger_hub/TerarangerOneConfig.h: No such file or directory
```
Maybe it is not the best solution, but we fixed it by changing the config file to the one in the original TeraRanger One ROS package.